### PR TITLE
Use verify_output()

### DIFF
--- a/tests/testthat/agrupada.txt
+++ b/tests/testthat/agrupada.txt
@@ -1,0 +1,74 @@
+
+media_argrupada()
+=================
+
+> cd <- configuracion_disenio(casen_2017_los_rios, "ytotcorh", c("comuna", "sexo"),
++ "expc")
+> media_agrupada(cd)
+# A tibble: 12 x 7
+   comuna_etiqueta sexo_etiqueta comuna_codigo sexo_codigo media_ytotcorh
+   <chr>           <chr>         <chr>         <chr>                <dbl>
+ 1 Valdivia        Mujer         14101         2                 1262564.
+ 2 Valdivia        Hombre        14101         1                 1347409.
+ 3 Los Lagos       Hombre        14104         1                  718525.
+ 4 Los Lagos       Mujer         14104         2                  730578.
+ 5 Paillaco        Hombre        14107         1                  707612.
+ 6 Paillaco        Mujer         14107         2                  689113.
+ 7 Panguipulli     Mujer         14108         2                  631138.
+ 8 Panguipulli     Hombre        14108         1                  684710.
+ 9 La Unión        Hombre        14201         1                  804543.
+10 La Unión        Mujer         14201         2                  751564.
+11 Río Bueno       Hombre        14204         1                  772788.
+12 Río Bueno       Mujer         14204         2                  713756.
+# ... with 2 more variables: media_ytotcorh_inf <dbl>, media_ytotcorh_sup <dbl>
+
+
+mediana_argrupada()
+===================
+
+> cd <- configuracion_disenio(casen_2017_los_rios, "ytotcorh", c("comuna", "sexo"),
++ "expc")
+> mediana_agrupada(cd)
+# A tibble: 12 x 7
+   comuna_etiqueta sexo_etiqueta comuna_codigo sexo_codigo mediana_ytotcorh
+   <chr>           <chr>         <chr>         <chr>                  <dbl>
+ 1 Valdivia        Mujer         14101         2                    900000 
+ 2 Valdivia        Hombre        14101         1                    914376.
+ 3 Los Lagos       Hombre        14104         1                    612354.
+ 4 Los Lagos       Mujer         14104         2                    635936 
+ 5 Paillaco        Hombre        14107         1                    553684 
+ 6 Paillaco        Mujer         14107         2                    532639.
+ 7 Panguipulli     Mujer         14108         2                    532261.
+ 8 Panguipulli     Hombre        14108         1                    559715.
+ 9 La Unión        Hombre        14201         1                    622461 
+10 La Unión        Mujer         14201         2                    567739.
+11 Río Bueno       Hombre        14204         1                    696373.
+12 Río Bueno       Mujer         14204         2                    631806 
+# ... with 2 more variables: mediana_ytotcorh_inf <dbl>,
+#   mediana_ytotcorh_sup <dbl>
+
+
+percentiles_agrupados()
+=======================
+
+> cd <- configuracion_disenio(casen_2017_los_rios, "ytotcorh", c("comuna", "sexo"),
++ "expc")
+> percentiles_agrupados(cd, 0.7)
+# A tibble: 12 x 7
+   percentil comuna_etiqueta sexo_etiqueta comuna_codigo sexo_codigo
+       <dbl> <chr>           <chr>         <chr>         <chr>      
+ 1       0.7 Valdivia        Mujer         14101         2          
+ 2       0.7 Valdivia        Hombre        14101         1          
+ 3       0.7 Los Lagos       Hombre        14104         1          
+ 4       0.7 Los Lagos       Mujer         14104         2          
+ 5       0.7 Paillaco        Hombre        14107         1          
+ 6       0.7 Paillaco        Mujer         14107         2          
+ 7       0.7 Panguipulli     Mujer         14108         2          
+ 8       0.7 Panguipulli     Hombre        14108         1          
+ 9       0.7 La Unión        Hombre        14201         1          
+10       0.7 La Unión        Mujer         14201         2          
+11       0.7 Río Bueno       Hombre        14204         1          
+12       0.7 Río Bueno       Mujer         14204         2          
+# ... with 2 more variables: mediana_ytotcorh <dbl>,
+#   mediana_ytotcorh_err_est <dbl>
+

--- a/tests/testthat/test-descriptive_statistics.R
+++ b/tests/testthat/test-descriptive_statistics.R
@@ -1,22 +1,15 @@
 context("testthat.R")
 
-test_that("media_agrupada works properly", {
+verify_output("agrupada.txt", {
+  "# media_argrupada()"
   cd <- configuracion_disenio(casen_2017_los_rios, "ytotcorh", c("comuna", "sexo"), "expc")
-  est <- media_agrupada(cd)
-  expect_is(est, "data.frame")
-  expect_output(str(est), "7 variables")
-})
+  media_agrupada(cd)
 
-test_that("mediana_agrupada works properly", {
+  "# mediana_argrupada()"
   cd <- configuracion_disenio(casen_2017_los_rios, "ytotcorh", c("comuna", "sexo"), "expc")
-  est <- mediana_agrupada(cd)
-  expect_is(est, "data.frame")
-  expect_output(str(est), "7 variables")
-})
+  mediana_agrupada(cd)
 
-test_that("percentiles_agrupados works properly", {
+  "# percentiles_agrupados()"
   cd <- configuracion_disenio(casen_2017_los_rios, "ytotcorh", c("comuna", "sexo"), "expc")
-  est <- percentiles_agrupados(cd, 0.7)
-  expect_is(est, "data.frame")
-  expect_output(str(est), "7 variables")
+  percentiles_agrupados(cd, 0.7)
 })


### PR DESCRIPTION
for less brittle output tests.

This fix will allow you to submit an update to CRAN. Subsequent changes to tibble's output routines will no longer break CRAN checks. In addition I'd suggest to rephrase the tests so that they test actual column names and values.

Closes #9.